### PR TITLE
WriteCsv class writes out defualt values

### DIFF
--- a/src/otoole/results/results.py
+++ b/src/otoole/results/results.py
@@ -92,6 +92,11 @@ class ReadResults(ReadStrategy):
         output_data = input_data.copy()
 
         for param in parameters:
+
+            # skip empty sets
+            if "indices" not in self.user_config[param]:
+                continue
+
             indices = []
             for index in self.user_config[param]["indices"]:
                 indices.append(input_data[index]["VALUE"].to_list())  # get set values

--- a/src/otoole/write_strategies.py
+++ b/src/otoole/write_strategies.py
@@ -191,7 +191,13 @@ class WriteCsv(WriteStrategy):
         self._write_out_dataframe(self.filepath, set_name, df, index=False)
 
     def _footer(self, handle: TextIO):
-        pass
+        # writes out default_values.csv
+        if self.default_values:
+            df = pd.DataFrame().from_dict(
+                self.default_values, orient="index", columns=["default_value"]
+            )
+            df = df.reset_index().rename({"index": "name"}, axis=1)
+            self._write_out_dataframe(self.filepath, "default_values", df, index=False)
 
 
 class WriteDatapackage(WriteStrategy):


### PR DESCRIPTION
In this pull request I have: 
- Fixed an error when expanding default dataframes during the result writing process
- Added writing out default_csv functionality to the WriteCSV class. 